### PR TITLE
Make APIKey public for outside usage

### DIFF
--- a/DiningStack/DataManager.swift
+++ b/DiningStack/DataManager.swift
@@ -37,7 +37,7 @@ internal enum Router: URLStringConvertible {
     Keys for Cornell API
     These will be in the response dictionary
 */
-internal enum APIKey : String {
+public enum APIKey : String {
     // Top Level
     case Status    = "status"
     case Data      = "data"


### PR DESCRIPTION
The today extension accesses the APIKey enum, but internal only give access to the module.